### PR TITLE
Add backwards-compatible option to prefix environment variables

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-// Parse takes in a struct and attempts to fill it using environment variables.
+// Parse creates a struct of type T and attempts to fill it using environment variables.
 // This behaviour can be adjusted through struct tags.
 // The "env" struct tag will set the name of the environment variable this function looks for.
 // If strings are passed as arguments to Parse, then they will be joined with "_" and the resulting string, with a trailing "_", will be used as a prefix for the capitalized field name or the value of the "env" tag.
@@ -32,6 +32,10 @@ func Parse[T any](scopes ...string) (*T, error) {
 
 		raw_env_name, has_env_tag := f_t.Tag.Lookup("env")
 		env_name := name(raw_env_name, scopes...)
+
+		if raw_env_name == "-" {
+			continue
+		}
 
 		if !has_env_tag {
 			env_name = name(strings.ToUpper(f_t.Name), scopes...)

--- a/parsing.go
+++ b/parsing.go
@@ -7,6 +7,13 @@ import (
 	"time"
 )
 
+// Parse takes in a struct and attempts to fill it using environment variables.
+// This behaviour can be adjusted through struct tags.
+// The "env" struct tag will set the name of the environment variable this function looks for.
+// If it isn't set, then the uppercased name of the field will be used.
+// If the "binding" tag is set to "required", then an error will be thrown if the environment variable is unset.
+// Otherwise, a default value will be used.
+// The default value can be set by using the "default" tag.
 func Parse[T any](scopes ...string) (*T, error) {
 	ptr := new(T)
 	ptr_t := reflect.TypeOf(ptr)

--- a/parsing.go
+++ b/parsing.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func Parse[T any]() (*T, error) {
+func Parse[T any](scopes ...string) (*T, error) {
 	ptr := new(T)
 	ptr_t := reflect.TypeOf(ptr)
 	ptr_v := reflect.ValueOf(ptr)
@@ -22,10 +22,11 @@ func Parse[T any]() (*T, error) {
 		f_t := obj_t.Field(i)
 		f_v := obj_v.Field(i)
 
-		env_name, has_env_tag := f_t.Tag.Lookup("env")
+		raw_env_name, has_env_tag := f_t.Tag.Lookup("env")
+		env_name := name(raw_env_name, scopes...)
 
 		if !has_env_tag {
-			env_name = strings.ToUpper(f_t.Name)
+			env_name = name(strings.ToUpper(f_t.Name), scopes...)
 		}
 
 		def_val, has_default := f_t.Tag.Lookup("default")
@@ -78,4 +79,11 @@ func Parse[T any]() (*T, error) {
 		}
 	}
 	return ptr, nil
+}
+
+func name(name string, parts ...string) string {
+	if len(parts) > 0 {
+		return fmt.Sprintf("%s_%s", strings.Join(parts, "_"), name)
+	}
+	return name
 }

--- a/parsing.go
+++ b/parsing.go
@@ -10,6 +10,7 @@ import (
 // Parse takes in a struct and attempts to fill it using environment variables.
 // This behaviour can be adjusted through struct tags.
 // The "env" struct tag will set the name of the environment variable this function looks for.
+// If strings are passed as arguments to Parse, then they will be joined with "_" and the resulting string, with a trailing "_", will be used as a prefix for the capitalized field name or the value of the "env" tag.
 // If it isn't set, then the uppercased name of the field will be used.
 // If the "binding" tag is set to "required", then an error will be thrown if the environment variable is unset.
 // Otherwise, a default value will be used.

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -16,6 +16,11 @@ type structUnsupportedType struct {
 	UnsupportedField any
 }
 
+type structTestSkip struct {
+	Working          string `env:"TEST_STRING_WOKRING" default:"working"`
+	UnsupportedField any    `env:"-"`
+}
+
 type structString struct {
 	StringField         string `env:"TEST_STRING" binding:"required"`
 	OptionalStringField string `env:"OPTIONAL_TEST_STRING" default:"test_default_value"`
@@ -432,5 +437,19 @@ func TestName(t *testing.T) {
 				t.Errorf("wanted '%s', got '%s'", c.Want, res)
 			}
 		})
+	}
+}
+
+func TestParseSkip(t *testing.T) {
+	// test that skipping a field work
+	// if this works, then the struct should parse fine
+	// otherwise, there should be an error
+	res, err := Parse[structTestSkip]()
+	if err != nil {
+		t.Errorf("expected no error, got: %s", err.Error())
+	}
+
+	if res == nil {
+		t.Errorf("expected result, got nil")
 	}
 }

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -404,4 +404,8 @@ func TestParseBool(t *testing.T) {
 	if err == nil {
 		t.Error("expected error, got nothing")
 	}
+
+	if res != nil {
+		t.Errorf("expected nil, got %#v", *res)
+	}
 }

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -409,3 +409,28 @@ func TestParseBool(t *testing.T) {
 		t.Errorf("expected nil, got %#v", *res)
 	}
 }
+
+func TestName(t *testing.T) {
+	cases := []struct {
+		CaseName string
+		Name     string
+		Scopes   []string
+		Want     string
+	}{
+		{"NameExtrasNil", "TEST", nil, "TEST"},
+		{"NameExtrasEmpty", "TEST", []string{}, "TEST"},
+		{"NameOneExtra", "TEST", []string{"SCOPE1"}, "SCOPE1_TEST"},
+		{"NameThreeExtras", "TEST", []string{"ONE", "TWO", "THREE"}, "ONE_TWO_THREE_TEST"},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.CaseName, func(t *testing.T) {
+			t.Parallel()
+			res := name(c.Name, c.Scopes...)
+			if res != c.Want {
+				t.Errorf("wanted '%s', got '%s'", c.Want, res)
+			}
+		})
+	}
+}

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+type structSingle struct {
+	Field string `env:"TEST_SINGLE" default:"default"`
+}
+
 type structUnexportedField struct {
 	unexportedField string
 }
@@ -451,5 +455,44 @@ func TestParseSkip(t *testing.T) {
 
 	if res == nil {
 		t.Errorf("expected result, got nil")
+	}
+}
+
+func TestParseScoped(t *testing.T) {
+	cases := []struct {
+		Name   string
+		Envar  string
+		Enval  string
+		Want   string
+		Scopes []string
+	}{
+		{"EnvOKPrefixNil", "TEST_SINGLE", "environment", "environment", nil},
+		{"EnvBadPrefixNil", "NOT_TEST_SINGLE", "environment", "default", nil},
+		{"EnvOKPrefixEmpty", "TEST_SINGLE", "environment", "environment", []string{}},
+		{"EnvBadPrefixEmpty", "NOT_TEST_SINGLE", "environment", "default", []string{}},
+		{"EnvOKSinglePrefix", "PREFIX_TEST_SINGLE", "environment", "environment", []string{"PREFIX"}},
+		{"EnvBadSinglePrefix", "NOT_PREFIX_TEST_SINGLE", "environment", "default", []string{"PREFIX"}},
+		{"EnvNoPrefixSinglePrefix", "TEST_SINGLE", "environment", "default", []string{"PREFIX"}}, // making sure that the prefix isn't getting ignored, EnOKSinglePrefix would catch it but this makes origin clearer
+		{"EnvOkTwoPrefix", "PRE_FIX_TEST_SINGLE", "environment", "environment", []string{"PRE", "FIX"}},
+		{"EnvBadTwoPrefix", "NOT_PRE_FIX_TEST_SINGLE", "environment", "default", []string{"PRE", "FIX"}},
+		{"EnvNoPrefixTwoPrefix", "TEST_SINGLE", "environment", "default", []string{"PRE", "FIX"}}, // same as EnvNoPrefixSinglePrefix :>
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			os.Setenv(c.Envar, c.Enval)
+			res, err := Parse[structSingle](c.Scopes...)
+			if err != nil {
+				t.Errorf("expected no error, got %s", err.Error())
+			}
+
+			if res == nil {
+				t.Error("expected result, got nil")
+			} else if res.Field != c.Want {
+				t.Errorf("wanted '%s', got '%s'", c.Want, res.Field)
+			}
+			os.Unsetenv(c.Envar)
+		})
 	}
 }


### PR DESCRIPTION
There can sometimes be a need to reuse a configuration struct but setting different values (connecting to two different databases, ...).
Currently, this isn't possible without creating a second struct, since the environment variable names will conflict.
This allows an user to optionally pass one (or multiple) strings to Parse(), which will get appended to the start of the variable name. For example, passing `PREFIX` will result in a variable that used to be `MY_VAR` to become `PREFIX_MY_VAR`.
This also allows one to skip a struct field by setting the `env` tag to `-`