### PR TITLE
feat: allow some level of recursion (embedded structs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ Currently supported types for fields are:
 - `float32`, `float64`
 - `time.Duration`
 - `bool`
+- a further configuration `struct`, with a recursion limit of `10` embedded structs.

--- a/parsing.go
+++ b/parsing.go
@@ -66,6 +66,25 @@ func parseStruct(t reflect.Type, v reflect.Value, maxDepth uint, scopes ...strin
 
 		required := strings.ToLower(f_t.Tag.Get("binding")) == "required"
 
+		if f_v.Kind() == reflect.Struct {
+			if maxDepth < 1 {
+				return fmt.Errorf("field %s: max recursion depth exceeded", f_t.Name)
+			}
+
+			prefix, ok := f_t.Tag.Lookup("prefix")
+
+			if !ok {
+				return fmt.Errorf("field %s: embedded structs should have a 'prefix' key", f_t.Name)
+			}
+
+			subscopes := []string{prefix}
+			subscopes = append(subscopes, scopes...)
+
+			if err := parseStruct(f_t.Type, f_v, maxDepth-1, subscopes...); err != nil {
+				return fmt.Errorf("struct field %s: %s", f_t.Name, err.Error())
+			}
+		}
+
 		if !f_v.CanSet() {
 			return fmt.Errorf("field %s: not assignable", f_t.Name)
 		}

--- a/parsing.go
+++ b/parsing.go
@@ -83,6 +83,8 @@ func parseStruct(t reflect.Type, v reflect.Value, maxDepth uint, scopes ...strin
 			if err := parseStruct(f_t.Type, f_v, maxDepth-1, subscopes...); err != nil {
 				return fmt.Errorf("struct field %s: %s", f_t.Name, err.Error())
 			}
+
+			continue
 		}
 
 		if !f_v.CanSet() {

--- a/parsing.go
+++ b/parsing.go
@@ -22,6 +22,11 @@ import (
 // If the "binding" tag is set to "required", then an error will be thrown if the environment variable is unset.
 // Otherwise, a default value will be used.
 // The default value can be set by using the "default" tag.
+// Embedded structs are allowed.
+// There is a limit to recursion. Currently this is hard-coded to 10.
+// Embedded structs should have a prefix set using the 'prefix' struct tag, otherwise an error will be returned.
+// This prefix acts in a similar way to scopes.
+// It is added all the way at the front, then any scopes from the parent call.
 func Parse[T any](scopes ...string) (*T, error) {
 	ptr := new(T)
 	ptr_t := reflect.TypeOf(ptr)
@@ -34,6 +39,7 @@ func Parse[T any](scopes ...string) (*T, error) {
 	return ptr, nil
 }
 
+// name returns the full name that will be looked for based on the name provided and prefixes.
 func name(name string, parts ...string) string {
 	if len(parts) > 0 {
 		return fmt.Sprintf("%s_%s", strings.Join(parts, "_"), name)
@@ -41,6 +47,8 @@ func name(name string, parts ...string) string {
 	return name
 }
 
+// parseStruct does the actual parsing.
+// it is split out so embedded structs can be parsed recursively easily.
 func parseStruct(t reflect.Type, v reflect.Value, maxDepth uint, scopes ...string) (err error) {
 
 	if v.Kind() != reflect.Struct {

--- a/parsing.go
+++ b/parsing.go
@@ -26,16 +26,30 @@ func Parse[T any](scopes ...string) (*T, error) {
 	ptr := new(T)
 	ptr_t := reflect.TypeOf(ptr)
 	ptr_v := reflect.ValueOf(ptr)
-	obj_t := ptr_t.Elem()
-	obj_v := ptr_v.Elem()
 
-	if obj_v.Kind() != reflect.Struct {
-		return nil, fmt.Errorf("expected struct, got %s", obj_v.Kind())
+	if err := parseStruct(ptr_t.Elem(), ptr_v.Elem(), 10, scopes...); err != nil {
+		return nil, err
 	}
 
-	for i := 0; i < obj_v.NumField(); i++ {
-		f_t := obj_t.Field(i)
-		f_v := obj_v.Field(i)
+	return ptr, nil
+}
+
+func name(name string, parts ...string) string {
+	if len(parts) > 0 {
+		return fmt.Sprintf("%s_%s", strings.Join(parts, "_"), name)
+	}
+	return name
+}
+
+func parseStruct(t reflect.Type, v reflect.Value, maxDepth uint, scopes ...string) (err error) {
+
+	if v.Kind() != reflect.Struct {
+		return fmt.Errorf("expected struct, got %s", v.Kind())
+	}
+
+	for i := range v.NumField() {
+		f_t := t.Field(i)
+		f_v := v.Field(i)
 
 		raw_env_name, has_env_tag := f_t.Tag.Lookup("env")
 		env_name := name(raw_env_name, scopes...)
@@ -53,56 +67,50 @@ func Parse[T any](scopes ...string) (*T, error) {
 		required := strings.ToLower(f_t.Tag.Get("binding")) == "required"
 
 		if !f_v.CanSet() {
-			return nil, fmt.Errorf("field %s: not assignable", f_t.Name)
+			return fmt.Errorf("field %s: not assignable", f_t.Name)
 		}
 
 		switch f_v.Interface().(type) {
 		case string:
 			res, err := pstring.ParseWithDefault(env_name, required, def_val, has_default)
 			if err != nil {
-				return nil, fmt.Errorf("field %s: %s", f_t.Name, err.Error())
+				return fmt.Errorf("field %s: %s", f_t.Name, err.Error())
 			}
 			f_v.SetString(res)
 		case int, int8, int16, int32, int64:
 			res, err := pint.Parse(env_name, required, def_val, has_default)
 			if err != nil {
-				return nil, fmt.Errorf("field %s: %s", f_t.Name, err.Error())
+				return fmt.Errorf("field %s: %s", f_t.Name, err.Error())
 			}
 			f_v.SetInt(res) // TODO; check if this truncates if assigning a number with higher bitsize to a field with smaller bitsize (for example in16-size number into int8)/
 		case float32, float64:
 			res, err := pfloat.Parse(env_name, required, def_val, has_default)
 			if err != nil {
-				return nil, fmt.Errorf("field %s: %s", f_t.Name, err.Error())
+				return fmt.Errorf("field %s: %s", f_t.Name, err.Error())
 			}
 			f_v.SetFloat(res)
 		case uint, uint8, uint16, uint32, uint64:
 			res, err := puint.Parse(env_name, required, def_val, has_default)
 			if err != nil {
-				return nil, fmt.Errorf("field %s: %s", f_t.Name, err.Error())
+				return fmt.Errorf("field %s: %s", f_t.Name, err.Error())
 			}
 			f_v.SetUint(res)
 		case time.Duration:
 			res, err := pduration.Parse(env_name, required, def_val, has_default)
 			if err != nil {
-				return nil, fmt.Errorf("field %s: %s", f_t.Name, err.Error())
+				return fmt.Errorf("field %s: %s", f_t.Name, err.Error())
 			}
 			f_v.Set(reflect.ValueOf(res))
 		case bool:
 			res, err := pbool.Parse(env_name, required, def_val, has_default)
 			if err != nil {
-				return nil, fmt.Errorf("field %s: %s", f_t.Name, err.Error())
+				return fmt.Errorf("field %s: %s", f_t.Name, err.Error())
 			}
 			f_v.SetBool(res)
 		default:
-			return nil, fmt.Errorf("field %s: unsupported type %s", f_t.Name, f_v.Kind())
+			return fmt.Errorf("field %s: unsupported type %s", f_t.Name, f_v.Kind())
 		}
 	}
-	return ptr, nil
-}
 
-func name(name string, parts ...string) string {
-	if len(parts) > 0 {
-		return fmt.Sprintf("%s_%s", strings.Join(parts, "_"), name)
-	}
-	return name
+	return nil
 }

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -67,6 +67,70 @@ type structEmbeddedInside struct {
 	StringField string `env:"TEST_STRING" default:"default"`
 }
 
+type StructTooDeepA struct {
+	Embedded StructTooDeepB `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepB struct {
+	Embedded StructTooDeepC `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepC struct {
+	Embedded StructTooDeepD `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepD struct {
+	Embedded StructTooDeepE `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepE struct {
+	Embedded StructTooDeepF `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepF struct {
+	Embedded StructTooDeepG `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepG struct {
+	Embedded StructTooDeepH `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepH struct {
+	Embedded StructTooDeepI `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepI struct {
+	Embedded StructTooDeepJ `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepJ struct {
+	Embedded StructTooDeepK `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepK struct {
+	Embedded StructTooDeepL `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepL struct {
+	Embedded StructTooDeepM `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepM struct {
+	Embedded StructTooDeepN `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepN struct {
+	Embedded StructTooDeepO `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepO struct {
+	Embedded StructTooDeepP `prefix:"EMBEDDED"`
+}
+
+type StructTooDeepP struct {
+	Embedded string `env:"CATCH_ME_IF_YOU_CAN" default:"deep"`
+}
+
 func TestParseNotStruct(t *testing.T) {
 	res, err := Parse[int]()
 	if err == nil {
@@ -513,5 +577,16 @@ func TestParseEmbedded(t *testing.T) {
 
 	if res.Embedded.StringField != "default" {
 		t.Errorf("expected 'default', got '%s'", res.Embedded.StringField)
+	}
+}
+
+func TestParseEmbeddedInfiniteRecursion(t *testing.T) {
+	res, err := Parse[StructTooDeepA]()
+	if err == nil {
+		t.Error("expected error, got none")
+	}
+
+	if res != nil {
+		t.Error("expected no result, got one")
 	}
 }

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -131,6 +131,10 @@ type StructTooDeepP struct {
 	Embedded string `env:"CATCH_ME_IF_YOU_CAN" default:"deep"`
 }
 
+type StructEmbeddedNoPrefix struct {
+	Embedded structEmbeddedInside
+}
+
 func TestParseNotStruct(t *testing.T) {
 	res, err := Parse[int]()
 	if err == nil {
@@ -582,6 +586,17 @@ func TestParseEmbedded(t *testing.T) {
 
 func TestParseEmbeddedInfiniteRecursion(t *testing.T) {
 	res, err := Parse[StructTooDeepA]()
+	if err == nil {
+		t.Error("expected error, got none")
+	}
+
+	if res != nil {
+		t.Error("expected no result, got one")
+	}
+}
+
+func TestParseEmbeddedNoPrefix(t *testing.T) {
+	res, err := Parse[StructEmbeddedNoPrefix]()
 	if err == nil {
 		t.Error("expected error, got none")
 	}

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -59,6 +59,14 @@ type structBool struct {
 	OptionalBoolField bool `env:"OPTIONAL_TEST_BOOL" default:"true"`
 }
 
+type structEmbeddedOutside struct {
+	Embedded structEmbeddedInside `prefix:"INNER"`
+}
+
+type structEmbeddedInside struct {
+	StringField string `env:"TEST_STRING" default:"default"`
+}
+
 func TestParseNotStruct(t *testing.T) {
 	res, err := Parse[int]()
 	if err == nil {
@@ -494,5 +502,16 @@ func TestParseScoped(t *testing.T) {
 			}
 			os.Unsetenv(c.Envar)
 		})
+	}
+}
+
+func TestParseEmbedded(t *testing.T) {
+	res, err := Parse[structEmbeddedOutside]()
+	if err != nil {
+		t.Fatalf("error: %s", err)
+	}
+
+	if res.Embedded.StringField != "default" {
+		t.Errorf("expected 'default', got '%s'", res.Embedded.StringField)
 	}
 }


### PR DESCRIPTION
this is done with a hardcoded limit on recursion for now. The limit is hardcoded to avoid changing the API. A further change should be made to either add an extra function to allow setting a custom recursion limit, or a breaking change could be made to make it a parameter of the top level Parse function, with a major version bump.